### PR TITLE
Enhance modal management by adding z-index handling

### DIFF
--- a/components/Common/ModalManager.tsx
+++ b/components/Common/ModalManager.tsx
@@ -4,7 +4,7 @@ import { useModal } from "@/contexts/ModalManagerProvider";
 import { ModalId, modalRegistry } from "@/types/modal";
 
 export const ModalManager = () => {
-  const { isModalOpen, closeModal, getModalProps } = useModal();
+  const { isModalOpen, closeModal, getModalProps, getModalZIndex } = useModal();
 
   return (
     <>
@@ -12,11 +12,20 @@ export const ModalManager = () => {
         const modalId = id as ModalId;
         const isOpen = isModalOpen(modalId);
         const modalProps = getModalProps(modalId) || {};
+        const zIndex = getModalZIndex(modalId);
 
         // Create a component that knows how to handle its own props
         const ModalComponent = Component as any;
 
-        return <ModalComponent key={id} isOpen={isOpen} onClose={() => closeModal(modalId)} {...modalProps} />;
+        return (
+          <ModalComponent
+            key={id}
+            isOpen={isOpen}
+            onClose={() => closeModal(modalId)}
+            zIndex={zIndex}
+            {...modalProps}
+          />
+        );
       })}
     </>
   );

--- a/components/Modal/NewRequestModal.tsx
+++ b/components/Modal/NewRequestModal.tsx
@@ -26,7 +26,7 @@ export function NewRequestModal({ isOpen, onClose }: ModalProp<SelectTokenModalP
   if (!isOpen) return null;
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose} title="Create New Request" icon="/modal/coin-icon.gif" zIndex={20}>
+    <BaseModal isOpen={isOpen} onClose={onClose} title="Create New Request" icon="/modal/coin-icon.gif">
       <div className="flex flex-col gap-0">
         <div className="flex flex-col rounded-b-2xl border border-solid bg-[#1E1E1E] border-zinc-800 max-h-[800px] overflow-y-auto w-[500px] p-2">
           {/* Amount */}

--- a/types/modal.ts
+++ b/types/modal.ts
@@ -24,6 +24,7 @@ export type ModalId = keyof typeof MODAL_IDS;
 
 export interface BaseModalProps {
   onClose: () => void;
+  zIndex?: number;
 }
 
 export interface SelectTokenModalProps extends BaseModalProps {}


### PR DESCRIPTION
- Introduced getModalZIndex function in ModalManagerProvider to dynamically calculate z-index for modals based on their opening order.
- Updated ModalManager to utilize the new zIndex prop for modals.
- Adjusted NewRequestModal to remove hardcoded zIndex, allowing for dynamic z-index management.