### PR TITLE
fix: docs image paths in bills.md

### DIFF
--- a/packages/docs/docs/bills.md
+++ b/packages/docs/docs/bills.md
@@ -11,7 +11,7 @@ Qash allows you to manage and pay invoices received from vendors, clients, and e
 
 The Bills page provides a comprehensive view of all invoices you've received.
 
-![Bills Overview Page](/img/bills/bill-overview.png)
+![Bills Overview Page](../static/img/bills/bill-overview.png)
 
 ### Bill Tabs
 
@@ -25,22 +25,22 @@ The Bills page is organized into three tabs:
 
 Click on any bill row to navigate to the detailed bill view, where you can see complete invoice information and timeline.
 
-![Bill Detail Page](/img/bills/bill-detail.png)
+![Bill Detail Page](../static/img/bills/bill-detail.png)
 
 ## Pay Bill Review Page
 
 The Pay Bill Review page allows you to review and pay one or multiple bills at once.
 
-![Pay Bill Review Page](/img/bills/bill-pay.png)
+![Pay Bill Review Page](../static/img/bills/bill-pay.png)
 
 You can also review the invoice here before making the final payment.
 
-![Invoice Review Modal](/img/bills/bill-invoice.png)
+![Invoice Review Modal](../static/img/bills/bill-invoice.png)
 
 Clicking the **`Pay Invoice`** button will start processing the payment.
 
-![Payment Processing](/img/bills/bill-processing.png)
+![Payment Processing](../static/img/bills/bill-processing.png)
 
 Finally, an overview of the payment is shown, including the transaction hash, link to explorer, and other transaction details.
 
-![Payment Overview](/img/bills/bill-paid.png)
+![Payment Overview](../static/img/bills/bill-paid.png)


### PR DESCRIPTION
Fix broken image paths in bills documentation so images render correctly in GitHub preview.
